### PR TITLE
focus on userbackends

### DIFF
--- a/pg_rage_terminator.c
+++ b/pg_rage_terminator.c
@@ -69,8 +69,8 @@ pg_rage_terminator_build_query(StringInfoData *buf)
                "pid, pg_terminate_backend(pid) as status, "
                "usename, datname, client_addr::text "
                "FROM pg_stat_activity "
-               "WHERE ((random() * 100)::int < %d) "
-               "AND pid != pg_backend_pid();",
+               "WHERE client_port IS NOT NULL",
+               "AND ((random() * 100)::int < %d) ",
                      chance);
     elog(DEBUG1, "Kill query is: %s", buf->data);
 }


### PR DESCRIPTION
backendworkers like autovacuum or analyze dont have a port, so unless we're trying to harden vacuum we can exclude all portless workers. Even substitutes the check for our own pid.

and i always wanted to create a pull request
